### PR TITLE
Add ISSUE_TEMPLATE for bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,38 @@
+name: Bug Report
+description: Problems and issues with code
+title: 'Bug Report: '
+labels: ['type: bug']
+body:
+  - type: textarea
+    attributes:
+      label: What happened?
+      description: Please provide as much info as possible. This will help other developers to fix bug easier.
+      placeholder: >
+        Please provide the context in which the problem occurred and explain what happened
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What you expected to happen
+      description: What do you think went wrong?
+      placeholder: >
+        Please explain why you think the behaviour is expected to output. Could be screenshots, UI or fragment of logs that show what you think went wrong.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: How to reproduce
+      placeholder: >
+        Please make sure you provide a reproducible step-by-step case of how to reproduce the problem
+        as minimally and precisely as possible. Keep in mind we do not have access to your local environment.
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Are you willing to submit PR?
+      description: >
+        This is absolutely not required, but it will be a huge help for the project.
+      multiple: true
+      options:
+        - 'Yes I am willing to submit a PR!'


### PR DESCRIPTION
I think this bug report template will keep track of what other people think went wrong with this project.

-------
## Docs
### Implement a template for issues (#215)
An `ISSUE_TEMPLATE/bug.yml` has been added to the project in order to facilitate bug reports.