### PR TITLE
CI - Tag-release-publish - Use Node.js v18

### DIFF
--- a/.github/workflows/tag-release-publish.yml.yml
+++ b/.github/workflows/tag-release-publish.yml.yml
@@ -21,7 +21,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: DazzlingFugu/.github/.github/workflows/js--tag-release-publish.yml@master
     with:
-      node-version: 12
+      node-version: 18
       package-manager: yarn
     secrets:
       npm-automation-token: ${{ secrets.NPM_AUTOMATION_TOKEN }}


### PR DESCRIPTION
## CI

### Workflow "tag-release-publish", use Node.js v18 (#261)

---

Twin PR with: https://github.com/DazzlingFugu/ember-cli-embedded/pull/310
