### PR TITLE
Release v5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-feature-controls",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "description": "Hot plug your features.",
   "keywords": [
     "ember",


### PR DESCRIPTION
## Breaking changes

### Upgrade add-on to Ember.js v5.4.0 (#255)

- Ember.js v4.8 or above is now required
- Ember CLI v4.8 or above is now required
- Node.js v18 or above is now required

## Chore

### Auto-update contributors list (GH Action) (#202)

### Add `ISSUE_TEMPLATE` for bug report` (#215)

### Partially migrate add-on to TypeScript (#255)

- The add-on is not 100% TypeScript-based yet, but it was regenerated as if it was, with the latest specification and the `--typescript` flag.
  - https://github.com/ember-cli/ember-cli/releases/tag/v4.9.0
  - https://github.com/ember-cli/ember-cli/pull/9972

  which also means it does not rely on `ember-cli-typescript` anymore:
  - https://github.com/ember-cli/ember-cli/pull/10283

## Build

- Bump `eslint-plugin-qunit` from 7.2.0 to 7.3.1 (#199)
- Bump `eslint-plugin-prettier` from 4.0.0 to 4.2.1 (#200)
- Bump `eslint-plugin-n` from 15.2.1 to 15.2.4 (#203)
- Bump `eslint` from 8.21.0 to 8.22.0 (#204)
- Bump `@glimmer/tracking` from 1.0.4 to 1.1.2 (#205)
- Bump `prettier` from 2.5.1 to 2.7.1 (#206)
- Bump `ember-auto-import` from 2.4.0 to 2.4.2 (#207)
- Bump `@embroider/test-setup` from 1.6.0 to 1.8.3 (#208)
- Bump `ember-local-storage` from 2.0.1 to 2.0.4 (#210)
- Bump `ember-truth-helpers` from 3.0.0 to 3.1.1 (#211)
- Bump `webpack` from 5.66.0 to 5.74.0 (#212)
- Bump `eslint-plugin-n` from 15.2.4 to 15.3.0 (#213)
- Bump `mout` from 1.2.3 to 1.2.4 (#214)
- Bump `@babel/core` from 7.18.10 to 7.20.2 (#222)
- Bump `loader-utils` from 1.4.0 to 1.4.1 (#223)
- Bump `socket.io-parser` from 4.0.4 to 4.0.5 (#224)
- Bump `ember-cli-htmlbars` from 6.0.1 to 6.1.1 (#228)
- Bump `loader-utils` from 1.4.1 to 1.4.2 (#230)
- Bump `eslint-config-prettier` from 8.3.0 to 8.5.0 (#232)
- Bump `prettier` from 2.7.1 to 2.8.0 (#234)
- Bump `decode-uri-component` from 0.2.0 to 0.2.2 (#237)
- Bump `express` from 4.17.2 to 4.18.2 (#241)
